### PR TITLE
Trimming size of the final image by multistaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
-FROM python:3.8.0-slim
+FROM python:3.8.0 AS build
 RUN apt-get update && apt-get install gcc -y && apt-get clean
-COPY requirements.txt /app/requirements.txt
-WORKDIR /app
+COPY requirements.txt requirements.txt
 RUN pip install --user --no-cache -r requirements.txt
+
+FROM python:3.8.0-slim AS production
+ENV PATH=/root/.local/bin:$PATH
+COPY --from=build /root/.local /root/.local
 COPY . .
 VOLUME [ "/data" ]
 ENTRYPOINT [ "python3", "your_script.py" ]


### PR DESCRIPTION
Some libraries aren't in the slim-tag (eg. curl).

But you could build with the full python image and still have a slim image by using multistaging.